### PR TITLE
feat: add option to allow userhandle & message arguments from the CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@ You can then run "`npm config set puppeteer_skip_chromium_download true`" after 
 
 Step 3 -> Create a `.env` file in the root and put in username & password just as in example file `.env.sample`
 
-Step 4 -> Go to the `index.js` file and type in the handle of the user you want to send a message on line 4
+Step 4 -> Go to the `index.js` file and type in the handle of the user you want to send a message on line 4 or You can enter the user handle & message as arguments from the command line when running the app and skip `Step 4` and `Step 5`
+e.g 
+
+
+```
+    node index.js --msg='Hello, World' --userHandle='blackjack'
+```
 
 Step 5 -> Still in the `index.js` file, type in the message you want to send on line 5
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,11 @@
 const dotenv = require('dotenv');
+const minimist = require('minimist');
 const instagrambot = require('./instagram');
 
-const userhandle = 'gbenga_ps'
-const MESSAGE = 'Yinka Alabi sent this test message. Kindly ignore.';
+const cli_args = minimist(process.argv.slice(2));
+
+const userhandle = cli_args['userHandle'] || 'gbenga_ps';
+const MESSAGE = cli_args['msg'] || 'Yinka Alabi sent this test message. Kindly ignore.';
 
 dotenv.config();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -187,9 +187,9 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -197,6 +197,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "license": "ISC",
   "dependencies": {
     "dotenv": "^8.0.0",
+    "minimist": "^1.2.0",
     "puppeteer": "^1.17.0"
   }
 }


### PR DESCRIPTION
Accept user handle & message as arguments from the command line when running the app instead of entering them into the `index.js` file


```
    node index.js --msg='Hello, World' --userHandle='blackjack'
```